### PR TITLE
refactor: Use lib/init.sh in all scan scripts

### DIFF
--- a/scripts/check-containers.sh
+++ b/scripts/check-containers.sh
@@ -20,9 +20,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/init.sh"
+
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 OUTPUT_DIR=""  # Will be set based on target or default
-TIMESTAMP=$(date "+%Y-%m-%dT%H%M%SZ")
 
 # Colors
 RED='\033[0;31m'
@@ -368,7 +370,7 @@ echo ""
 echo -e "${CYAN}Cross-referencing with CISA KEV catalog...${NC}"
 echo ""
 
-KEV_FILE="$REPO_DIR/data/kev-catalog.json"
+KEV_FILE="$SECURITY_REPO_DIR/data/kev-catalog.json"
 KEV_MATCHES=0
 
 cat > "$KEV_RESULTS" << EOF

--- a/scripts/check-host-security.sh
+++ b/scripts/check-host-security.sh
@@ -19,16 +19,10 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/init.sh"
 
-# Source toolkit info library
-if [ -f "$SCRIPT_DIR/lib/toolkit-info.sh" ]; then
-    source "$SCRIPT_DIR/lib/toolkit-info.sh"
-    init_toolkit_info "$SECURITY_REPO_DIR"
-fi
-
-# Use UTC for consistent timestamps across time zones
-TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 
 echo "Host OS Security Verification"
 echo "=============================="

--- a/scripts/check-kev.sh
+++ b/scripts/check-kev.sh
@@ -21,7 +21,7 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/init.sh"
 
 # KEV Catalog URLs and paths
 KEV_JSON_URL="https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
@@ -39,8 +39,8 @@ GREEN='\033[0;32m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
-# Timestamp
-TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 
 usage() {
     echo "Usage: $0 [vulnerability-scan-file]"

--- a/scripts/check-mac-addresses.sh
+++ b/scripts/check-mac-addresses.sh
@@ -22,38 +22,18 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Source shared libraries
-AUDIT_AVAILABLE=0
-TIMESTAMPS_AVAILABLE=0
-
-if [ -f "$SCRIPT_DIR/lib/audit-log.sh" ]; then
-    source "$SCRIPT_DIR/lib/audit-log.sh"
-    AUDIT_AVAILABLE=1
-fi
-
-if [ -f "$SCRIPT_DIR/lib/timestamps.sh" ]; then
-    source "$SCRIPT_DIR/lib/timestamps.sh"
-    TIMESTAMPS_AVAILABLE=1
-fi
+source "$SCRIPT_DIR/lib/init.sh"
 
 # Allow target directory to be specified as argument
-if [ -n "$1" ]; then
+if [ -n "${1:-}" ]; then
     TARGET_DIR="$1"
 else
     TARGET_DIR="$SECURITY_REPO_DIR"
 fi
 
-# Use standardized timestamps (UTC for consistency across time zones)
-if [ "$TIMESTAMPS_AVAILABLE" -eq 1 ]; then
-    TIMESTAMP=$(get_iso_timestamp)
-else
-    TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
-fi
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 REPO_NAME=$(basename "$TARGET_DIR")
-TOOLKIT_VERSION=$(git -C "$SECURITY_REPO_DIR" describe --tags --always 2>/dev/null || echo "unknown")
-TOOLKIT_COMMIT=$(git -C "$SECURITY_REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 # MAC address patterns (IEEE 802.3)
 MAC_PATTERN_COLON="([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}"

--- a/scripts/check-malware.sh
+++ b/scripts/check-malware.sh
@@ -21,46 +21,20 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Source shared libraries
-AUDIT_AVAILABLE=0
-TIMESTAMPS_AVAILABLE=0
-PROGRESS_AVAILABLE=0
-
-if [ -f "$SCRIPT_DIR/lib/audit-log.sh" ]; then
-    source "$SCRIPT_DIR/lib/audit-log.sh"
-    AUDIT_AVAILABLE=1
-fi
-
-if [ -f "$SCRIPT_DIR/lib/timestamps.sh" ]; then
-    source "$SCRIPT_DIR/lib/timestamps.sh"
-    TIMESTAMPS_AVAILABLE=1
-fi
-
-if [ -f "$SCRIPT_DIR/lib/progress.sh" ]; then
-    source "$SCRIPT_DIR/lib/progress.sh"
-    PROGRESS_AVAILABLE=1
-fi
-
-if [ -f "$SCRIPT_DIR/lib/toolkit-info.sh" ]; then
-    source "$SCRIPT_DIR/lib/toolkit-info.sh"
-    init_toolkit_info "$SECURITY_REPO_DIR"
-fi
+source "$SCRIPT_DIR/lib/init.sh"
 
 # Allow target directory to be specified as argument
-if [ -n "$1" ]; then
+if [ -n "${1:-}" ]; then
     TARGET_DIR="$1"
 else
     TARGET_DIR="$SECURITY_REPO_DIR"
 fi
 
-# Use standardized timestamps (UTC for consistency across time zones)
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 if [ "$TIMESTAMPS_AVAILABLE" -eq 1 ]; then
-    TIMESTAMP=$(get_iso_timestamp)
     DATE_STAMP=$(get_date_stamp)
 else
-    TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
     DATE_STAMP=$(date -u "+%Y-%m-%d")
 fi
 REPO_NAME=$(basename "$TARGET_DIR")

--- a/scripts/check-nvd-cves.sh
+++ b/scripts/check-nvd-cves.sh
@@ -31,12 +31,9 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/init.sh"
 
-# Source libraries
-source "$SCRIPT_DIR/lib/audit-log.sh" 2>/dev/null || AUDIT_AVAILABLE=0
-source "$SCRIPT_DIR/lib/timestamps.sh" 2>/dev/null || true
-source "$SCRIPT_DIR/lib/toolkit-info.sh" 2>/dev/null || true
+# Source NVD-specific libraries (not included in init.sh)
 source "$SCRIPT_DIR/lib/nvd/api.sh"
 source "$SCRIPT_DIR/lib/nvd/matcher.sh"
 
@@ -176,9 +173,9 @@ if [ -z "$INVENTORY_FILE" ] || [ ! -f "$INVENTORY_FILE" ]; then
     fi
 fi
 
-# Initialize
-TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
-FILENAME_TS=$(date -u "+%Y-%m-%d-T%H%M%SZ")
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
+FILENAME_TS=$(get_filename_timestamp)
 OUTPUT_DIR="$TARGET_DIR/.scans"
 OUTPUT_FILE="$OUTPUT_DIR/nvd-cve-scan-${FILENAME_TS}.txt"
 

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -27,7 +27,7 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/init.sh"
 
 # Exclusion config file
 PII_EXCLUDE_FILE=""
@@ -68,14 +68,6 @@ build_exclusions() {
 
     echo "$exclusions"
 }
-
-# Source audit logging library
-if [ -f "$SCRIPT_DIR/lib/audit-log.sh" ]; then
-    source "$SCRIPT_DIR/lib/audit-log.sh"
-    AUDIT_AVAILABLE=1
-else
-    AUDIT_AVAILABLE=0
-fi
 
 # Help function
 show_help() {
@@ -145,11 +137,9 @@ fi
 ALLOWLIST_DIR="$TARGET_DIR/.allowlists"
 ALLOWLIST_FILE="$ALLOWLIST_DIR/pii-allowlist"
 
-# Use UTC for consistent timestamps across time zones
-TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 REPO_NAME=$(basename "$TARGET_DIR")
-TOOLKIT_VERSION=$(git -C "$SECURITY_REPO_DIR" describe --tags --always 2>/dev/null || echo "unknown")
-TOOLKIT_COMMIT=$(git -C "$SECURITY_REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 # Files to scan (common text file types)
 INCLUDE_PATTERNS=(

--- a/scripts/check-secrets.sh
+++ b/scripts/check-secrets.sh
@@ -30,21 +30,7 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SECURITY_REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-
-# Source shared libraries
-AUDIT_AVAILABLE=0
-TIMESTAMPS_AVAILABLE=0
-
-if [ -f "$SCRIPT_DIR/lib/audit-log.sh" ]; then
-    source "$SCRIPT_DIR/lib/audit-log.sh"
-    AUDIT_AVAILABLE=1
-fi
-
-if [ -f "$SCRIPT_DIR/lib/timestamps.sh" ]; then
-    source "$SCRIPT_DIR/lib/timestamps.sh"
-    TIMESTAMPS_AVAILABLE=1
-fi
+source "$SCRIPT_DIR/lib/init.sh"
 
 # Help function
 show_help() {
@@ -116,15 +102,9 @@ fi
 ALLOWLIST_DIR="$TARGET_DIR/.allowlists"
 ALLOWLIST_FILE="$ALLOWLIST_DIR/secrets-allowlist"
 
-# Use standardized timestamps (UTC for consistency across time zones)
-if [ "$TIMESTAMPS_AVAILABLE" -eq 1 ]; then
-    TIMESTAMP=$(get_iso_timestamp)
-else
-    TIMESTAMP=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
-fi
+# Initialize toolkit (sets TIMESTAMP, TOOLKIT_VERSION, TOOLKIT_COMMIT)
+init_security_toolkit
 REPO_NAME=$(basename "$TARGET_DIR")
-TOOLKIT_VERSION=$(git -C "$SECURITY_REPO_DIR" describe --tags --always 2>/dev/null || echo "unknown")
-TOOLKIT_COMMIT=$(git -C "$SECURITY_REPO_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 FOUND_ISSUES=0
 ACCEPTED_COUNT=0


### PR DESCRIPTION
## Summary
- Replace manual library sourcing and timestamp/version boilerplate with centralized `lib/init.sh` library
- Refactored 8 scan scripts, reducing ~20-30 lines of duplicated code per script to 3 lines
- All 14 test suites pass

## Scripts Refactored
- `check-pii.sh`
- `check-secrets.sh`
- `check-malware.sh`
- `check-mac-addresses.sh`
- `check-host-security.sh`
- `check-kev.sh`
- `check-nvd-cves.sh`
- `check-containers.sh`

## Test plan
- [x] All existing tests pass (`./tests/run-all-tests.sh`)
- [x] Individual script help commands work
- [x] Scripts produce expected output format

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)