### PR TITLE
docs: Add malware scanner abstraction proposal

### DIFF
--- a/docs/MALWARE-SCANNER-ABSTRACTION.md
+++ b/docs/MALWARE-SCANNER-ABSTRACTION.md
@@ -1,0 +1,172 @@
+# Malware Scanner Abstraction Proposal
+
+**Issue:** #15 - ClamAV Requirement
+**Author:** Lead Software Developer
+**Status:** Proposal
+**Created:** 2026-02-03
+
+## Problem Statement
+
+The current `check-malware.sh` is tightly coupled to ClamAV:
+- Hard-coded path resolution for ClamAV binaries
+- ClamAV-specific database management
+- ClamAV-specific JSON metadata generation
+- Exit code 2 specifically means "ClamAV not installed"
+
+This creates problems for:
+1. **Windows users** - Windows Defender is built-in and more natural
+2. **Enterprise environments** - May mandate specific AV solutions (Sophos, ESET, etc.)
+3. **CI/CD pipelines** - Different runners have different tools available
+
+## Proposed Solution
+
+### Scanner Abstraction Layer
+
+Create a modular architecture similar to `lib/scanners/` for vulnerability scanning:
+
+```
+scripts/lib/malware/
+├── common.sh           # Shared utilities, interface definition
+├── clamav.sh           # ClamAV integration (current implementation)
+├── defender.ps1        # Windows Defender integration
+└── (future) eset.sh    # Enterprise scanner integrations
+```
+
+### Interface Contract
+
+Each scanner module must implement:
+
+```bash
+# Required functions (bash example)
+scanner_name()          # Return human-readable name
+scanner_available()     # Return 0 if scanner is installed/available
+scanner_version()       # Return version string
+scanner_run()           # Run scan, return 0=clean, 1=infected, 2=error
+scanner_update_defs()   # Update virus definitions (optional)
+```
+
+### Supported Scanners List
+
+```bash
+# Priority order - first available scanner is used
+SUPPORTED_SCANNERS=(
+    "clamav"      # ClamAV (Linux, macOS, Windows via WSL)
+    "defender"    # Windows Defender (Windows native)
+    # Future additions:
+    # "sophos"    # Sophos (Enterprise)
+    # "eset"      # ESET (Enterprise)
+)
+```
+
+### Auto-Detection Logic
+
+```bash
+detect_scanner() {
+    for scanner in "${SUPPORTED_SCANNERS[@]}"; do
+        source "$LIB_DIR/malware/${scanner}.sh" 2>/dev/null || continue
+        if scanner_available; then
+            echo "$scanner"
+            return 0
+        fi
+    done
+    return 1  # No supported scanner found
+}
+```
+
+### Configuration Override
+
+Allow users to specify a preferred scanner:
+
+```bash
+# In .security-toolkit.conf or environment
+MALWARE_SCANNER="clamav"  # Force specific scanner
+```
+
+## Implementation Plan
+
+### Phase 1: Abstraction (This Sprint)
+1. Extract ClamAV-specific code into `lib/malware/clamav.sh`
+2. Create `lib/malware/common.sh` with interface definition
+3. Refactor `check-malware.sh` to use abstraction layer
+4. Maintain backward compatibility (ClamAV still default)
+
+### Phase 2: Windows Defender (Next Sprint)
+1. Create `lib/malware/defender.ps1` module
+2. Create `Check-Malware.ps1` using PowerShell abstraction
+3. Add Windows CI testing
+
+### Phase 3: Documentation Update
+1. Update all ClamAV-specific documentation
+2. Create "Supported Scanners" documentation
+3. Add troubleshooting for each scanner
+
+## Exit Code Changes
+
+Current:
+- 0 = Pass (no malware)
+- 1 = Fail (malware detected or error)
+- 2 = ClamAV not installed
+
+Proposed:
+- 0 = Pass (no malware)
+- 1 = Fail (malware detected)
+- 2 = No supported scanner installed
+- 3 = Scanner error (database issue, etc.)
+
+## NIST Control Alignment
+
+SI-3 (Malicious Code Protection) requires:
+- Malicious code protection mechanisms at entry/exit points
+- **Automatic updates** of protection mechanisms
+- Periodic scans and real-time scans
+
+The abstraction supports this by:
+- Ensuring *some* scanner is available (not mandating which one)
+- Each module implements `scanner_update_defs()` for updates
+- Scan functionality remains the same regardless of backend
+
+## Migration Path
+
+### Backward Compatibility
+- Existing ClamAV users: No change required
+- Exit code 2 still means "no scanner" (not specifically ClamAV)
+- All existing command-line options preserved
+
+### Documentation Updates Required
+| File | Change |
+|------|--------|
+| CLAUDE.md | Update "Required for malware scan" |
+| INSTALLATION.md | Add scanner options section |
+| README.md | Update SI-3 description |
+| docs/DEPENDENCIES.md | Reframe as "Supported Scanners" |
+| docs/FAQ.md | Update troubleshooting |
+| docs/TROUBLESHOOTING.md | Add multi-scanner section |
+
+## Open Questions
+
+1. **Should we support multiple simultaneous scanners?**
+   - Pro: Defense in depth
+   - Con: Complexity, slower scans
+
+2. **How to handle scanner-specific features?**
+   - ClamAV has JSON metadata generation
+   - Defender has different output format
+   - Normalize to common format? Or preserve scanner-specific data?
+
+3. **Enterprise scanner licensing?**
+   - Some scanners require licenses
+   - Should we document license requirements?
+
+## Recommendation
+
+Proceed with Phase 1 (abstraction layer) this sprint. This:
+- Establishes the architecture
+- Maintains full backward compatibility
+- Enables Windows Defender support in next sprint
+- Reduces risk by keeping ClamAV as the proven default
+
+## References
+
+- [ClamAV Documentation](https://docs.clamav.net/)
+- [Windows Defender CLI](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/command-line-arguments-microsoft-defender-antivirus)
+- [NIST SP 800-53 SI-3](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final)


### PR DESCRIPTION
## Summary

Architecture proposal for Issue #15 (ClamAV Requirement).

## Problem

`check-malware.sh` is tightly coupled to ClamAV with 150+ references across the codebase. This prevents Windows users from using native Windows Defender and limits enterprise environments that mandate specific AV solutions.

## Proposed Solution

Scanner abstraction layer similar to `lib/scanners/` for vulnerability scanning:

```
scripts/lib/malware/
├── common.sh       # Shared interface
├── clamav.sh       # ClamAV (current)
├── defender.ps1    # Windows Defender (new)
```

## Key Design Decisions

- Auto-detect first available scanner
- Config override: `MALWARE_SCANNER=clamav`
- Backward compatible (ClamAV remains default)
- Normalized exit codes across scanners

## Implementation Phases

1. **Phase 1:** Extract ClamAV to module, create abstraction
2. **Phase 2:** Add Windows Defender support
3. **Phase 3:** Update documentation

## Test plan

- [ ] Review proposal for completeness
- [ ] Validate approach aligns with project patterns

Addresses #15

🤖 Generated with [Claude Code](https://claude.ai/code)