### PR TITLE
fix: Improve ClamAV test robustness in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,17 @@ jobs:
       - name: Update ClamAV database
         run: |
           sudo systemctl stop clamav-freshclam || true
-          sudo freshclam || echo "ClamAV update failed (non-critical)"
+          # Retry freshclam up to 3 times (mirrors can be slow/unavailable)
+          for i in 1 2 3; do
+            echo "Attempt $i: Updating ClamAV database..."
+            if sudo freshclam --stdout 2>&1; then
+              echo "ClamAV database updated successfully"
+              break
+            fi
+            [ $i -lt 3 ] && sleep 5
+          done
+          # Verify database exists (tests will skip gracefully if not)
+          ls -la /var/lib/clamav/*.cvd 2>/dev/null || echo "Warning: ClamAV database may not be available"
 
       - name: Make scripts executable
         run: chmod +x scripts/*.sh tests/*.sh

--- a/tests/test-malware.sh
+++ b/tests/test-malware.sh
@@ -79,17 +79,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Check if ClamAV is installed
+# Check if ClamAV is installed AND has a valid database
 check_clamav() {
+    local clamscan_path=""
+
+    # Find clamscan binary
     if command -v clamscan &>/dev/null; then
-        return 0
+        clamscan_path="clamscan"
     elif [ -x "/opt/homebrew/bin/clamscan" ]; then
-        return 0
+        clamscan_path="/opt/homebrew/bin/clamscan"
     elif [ -x "/usr/local/bin/clamscan" ]; then
-        return 0
+        clamscan_path="/usr/local/bin/clamscan"
     elif [ -x "/usr/bin/clamscan" ]; then
-        return 0
+        clamscan_path="/usr/bin/clamscan"
+    else
+        return 1
     fi
+
+    # Verify ClamAV has a valid database by running a quick version check
+    # clamscan --version returns database info if available
+    if $clamscan_path --version 2>/dev/null | grep -q "ClamAV"; then
+        # Try a quick scan to verify database is functional
+        # Create a temp file and scan it - this will fail if no database
+        local test_file
+        test_file=$(mktemp)
+        echo "test" > "$test_file"
+        if $clamscan_path --no-summary "$test_file" >/dev/null 2>&1; then
+            rm -f "$test_file"
+            return 0
+        fi
+        rm -f "$test_file"
+    fi
+
     return 1
 }
 


### PR DESCRIPTION
## Summary

Fixes the recurring Ubuntu CI failure where the Malware Scanner test suite fails because ClamAV is installed but the virus database isn't available.

## Changes

### tests/test-malware.sh
- Updated `check_clamav()` to verify the database is functional, not just that the binary exists
- Performs a quick test scan to confirm ClamAV can actually scan files
- Tests now skip gracefully if ClamAV has no database

### .github/workflows/ci.yml
- Added retry logic (3 attempts) for `freshclam` database download
- Added verification step to check if database files exist
- Better error messaging for debugging

## Root Cause

CI was installing ClamAV but the virus database download via `freshclam` was failing silently. The test only checked for the `clamscan` binary, not whether it could actually scan files.

## Test plan

- [ ] CI passes on Ubuntu with ClamAV + database
- [ ] CI passes on Ubuntu if database download fails (tests skip)
- [ ] Local tests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)