### PR TITLE
fix: QA Test Run 3 bug fixes (#162, #163, #164)

### DIFF
--- a/docs/DEMO-CHEAT-SHEET.md
+++ b/docs/DEMO-CHEAT-SHEET.md
@@ -348,6 +348,69 @@ SCREEN2CAM_DEVICE=/dev/video10
 
 The script is idempotent — it detects an existing screen2cam install in `/opt/screen2cam` and offers to restart if already streaming. No need to uninstall between runs.
 
+## Automated Demo (Virtual Camera + One Command)
+
+For live demos where your audience joins a video call, `join-live-demo.sh` automates the entire flow:
+
+1. Installs [screen2cam](https://github.com/brucedombrowski/screen2cam) (streams your desktop as a virtual camera)
+2. Opens your meeting URL in the browser
+3. Launches QuickStart with your pre-built config
+
+### Setup
+
+```bash
+# 1. Copy the example config and fill in your meeting URL + target IP
+cp demo_scanner.conf my-demo.conf
+nano my-demo.conf
+
+# 2. Run (from Kali with X11)
+./scripts/join-live-demo.sh my-demo.conf
+```
+
+### What Happens
+
+```
+Phase 1  Pre-flight checks (Linux, X11, existing processes)
+Phase 2  Clone/build screen2cam, load v4l2loopback kernel module
+Phase 3  Start virtual camera → "Select 'screen2cam' in your video app"
+Phase 4  Open meeting URL in browser → wait for you to join
+Phase 5  Launch QuickStart with config (scans run, audience watches)
+Cleanup  Ctrl+C or script exit stops screen2cam automatically
+```
+
+### Config File (`demo_scanner.conf`)
+
+Single config drives both screen2cam and QuickStart:
+
+```bash
+# Meeting
+MEETING_URL="https://teams.live.com/meet/..."
+
+# Target (same vars as demo_target.conf)
+REMOTE_HOST=10.0.0.244
+REMOTE_USER=payload
+SCAN_TYPE=host
+TARGET_LOCATION=remote
+AUTH_MODE=credentialed
+
+# screen2cam
+SCREEN2CAM_FPS=15
+SCREEN2CAM_DEVICE=/dev/video10
+```
+
+### Requirements
+
+| Item | Requirement |
+|------|-------------|
+| OS | Linux with X11 (tested on Kali) |
+| Internet | For screen2cam clone (first run only) |
+| sudo | For `/opt/screen2cam` install and kernel module |
+| Video app | Must support V4L2 camera selection (Teams, Zoom, Meet) |
+
+### Re-running
+
+The script is idempotent — it detects an existing screen2cam install in `/opt/screen2cam` and offers to restart if already streaming. No need to uninstall between runs.
+
 ## Key Demo Talking Points
 
 | Moment | Point |


### PR DESCRIPTION
## Summary

- **#162** — Fix integer comparison error in power settings check (`host-scan.sh:317`). `grep -oE '[0-9]+'` matched both `32` from `uint32` and `300`, producing a multi-line string that broke `[` comparison. Now uses `awk '{print $NF}'` to extract the value.
- **#163** — Add yellow warning note before remote Lynis audit so users aren't surprised by a second sudo password prompt during live demos. Applied to both `host-scan.sh` and `remote.sh` code paths.
- **#164** — Add configurable `MALWARE_SCAN_PATHS` variable (default: `~/`) and create `demo_target.conf` with narrow paths (`/tmp/demo-target-data /home/payload`) to bring demo ClamAV scan from ~100s down to seconds.

## Test plan

- [x] `./tests/run-all-tests.sh` — 16/17 suites pass (1 pre-existing failure in Scanner Modules Test 14, unrelated)
- [ ] LSE: verify #162 fix on Ubuntu target with `gsettings get org.gnome.desktop.session idle-delay`
- [ ] LSE: verify #163 warning displays before Lynis sudo prompt
- [ ] LSE: verify #164 demo scan completes in <30 seconds with `demo_target.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)